### PR TITLE
Feat: 블록 정렬 API 연동

### DIFF
--- a/src/service/admin-api.ts
+++ b/src/service/admin-api.ts
@@ -18,6 +18,7 @@ export async function fetchBlockList(token: string): Promise<Block[]> {
         },
     });
     const { data } = await response.json();
+    data.sort((a: Block, b: Block) => a.sequence - b.sequence);
     return data;
 }
 
@@ -27,6 +28,28 @@ export async function fetchVisitorInfo(token: string): Promise<Visitor> {
         headers: {
             Authorization: `Bearer ${token}`,
         },
+    });
+    const { data } = await response.json();
+    return data;
+}
+
+interface SortableBlock extends Block {
+    chosen?: boolean;
+}
+
+export async function updateBlockOrder(
+    token: string,
+    blocks: SortableBlock[],
+): Promise<Block[]> {
+    //sortableJs로 드래그한 block에서 chosen 속성 제거
+    const cleanedBlocks = blocks.map(({ chosen, ...block }) => block);
+    const response = await fetch('/api/link/update/order', {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ order: cleanedBlocks }),
     });
     const { data } = await response.json();
     return data;


### PR DESCRIPTION
## :white_check_mark:DONE
- 리스트 정렬 API 연동
- dragEnd, handleBlock 코드 중복 제거  >>  updateBlock 함수 
- 
## :white_check_mark:TODO
-  진짜 코드 정리
-  진짜 코드 정리하고 머지하기

## 🛠 트러블슈팅: `SortableJS` 사용 시 API 400 에러 발생

> 안녕하세요 팀원분들,
>아시는 분도 계시겠지만, 혹~시나 해서 공유드립니다. 제가 리스트 정렬 작업 중 SortableJS로 드래그했을 때만 API 400 에러가 발생하는 문제가 있었는데, 알고 보니 SortableJS가 추가한 chosen이라는 타입이 문제였습니다. 이 속성을 제거하고 API를 호출하니 정상적으로 작동했습니다.
>나중에 SortableJS 사용하실 때 참고하시면 좋을 것 같아 남깁니다! 혹시 비슷한 문제 겪으시면 도움 되시길 바랍니다. 😊

### 1. 문제 상황
- `SortableJS`로 블록을 드래그하여 순서를 변경할 때만 update API 호출 시 `400 Bad Request` 에러가 발생.
-  일반 위아래 버튼을 눌러 블록 순서를 변경할 때는 API가 정상적으로 동작.

### 2. 원인 분석

- 문제를 디버깅한 결과, `SortableJS`로 드래그한 블록 객체에 `chosen`이라는 추가 속성이 포함되어 있었음.
- 이 속성은 서버에서 처리되지 않으며, API 요청에서 예상하지 못한 데이터로 인해 400 에러가 발생.


### 3. 해결 방법

- API 호출 전에 `chosen` 속성을 제거하는 로직을 추가함.
- 드래그가 완료된 후, 블록 객체에서 `chosen` 속성을 필터링한 후 API로 전송하여 정상적으로 작동하게 됨.


```ts

// servise/admin-api.ts
export async function updateBlockOrder(
    token: string,
    blocks: SortableBlock[],
): Promise<Block[]> {
    //sortableJs로 드래그한 block에서 chosen 속성 제거
    const cleanedBlocks = blocks.map(({ chosen, ...block }) => block);
    const response = await fetch('/api/link/update/order', {
        method: 'POST',
        headers: {
            Authorization: `Bearer ${token}`,
            'Content-Type': 'application/json',
        },
        body: JSON.stringify({ order: cleanedBlocks }),
    });
    const { data } = await response.json();
    return data;
}

```

### 4. 결과

- `chosen` 속성을 제외한 후 API를 호출하니 정상적으로 200 응답을 받았으며, 블록 정렬이 서버에 정상 반영됨.