### PR TITLE
Feat: 이미지/구분선 블록 추가,수정 API / admin 블록 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,16 @@ const nextConfig = {
         CUSTOM_URL: process.env.NEXT_PUBLIC_KAKAO_URL, // CUSTOM_URL 추가
     },
     images: {
-        domains: ['img.youtube.com'],
+        remotePatterns: [
+            {
+                protocol: 'https',
+                hostname: 'img.youtube.com',
+            },
+            {
+                protocol: 'https',
+                hostname: 'cdn.pixabay.com',
+            },
+        ],
     },
 };
 

--- a/src/app/admin/block/divide/components/divide-form.tsx
+++ b/src/app/admin/block/divide/components/divide-form.tsx
@@ -14,12 +14,7 @@ export default function DivideForm({
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
 }) {
     return (
-        <form
-            method="POST"
-            action="/api/link/add"
-            onSubmit={onSubmit}
-            className="mb-10 flex flex-col gap-2"
-        >
+        <form onSubmit={onSubmit} className="mb-10 flex flex-col gap-2">
             <DivideSelector state={state} dispatch={dispatch} />
             <button type="submit" className="button color">
                 추가 완료

--- a/src/app/admin/block/divide/components/divide-form.tsx
+++ b/src/app/admin/block/divide/components/divide-form.tsx
@@ -1,23 +1,30 @@
 'use client';
 
-import { Dispatch } from 'react';
-import Image from 'next/image';
+import { useBlockSubmit } from 'hooks/useBlockSubmit';
 import DivideSelector from './divide-selector';
 
 export default function DivideForm({
-    state,
-    dispatch,
+    divideStyle,
+    title,
     onSubmit,
+    handleDivideStyleChange,
 }: {
-    state: Block;
-    dispatch: Dispatch<BlockFormAction>;
+    divideStyle: number;
+    title: string;
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+    handleDivideStyleChange: (index: number, title: string) => void;
 }) {
+    const { paramsId } = useBlockSubmit();
     return (
         <form onSubmit={onSubmit} className="mb-10 flex flex-col gap-2">
-            <DivideSelector state={state} dispatch={dispatch} />
+            <DivideSelector
+                divideStyle={divideStyle}
+                handleDivideStyleChange={handleDivideStyleChange}
+            />
+            <input type="hidden" name="style" value={divideStyle} />
+            <input type="hidden" name="title" value={title} />
             <button type="submit" className="button color">
-                추가 완료
+                {paramsId ? '수정 완료' : '추가 완료'}
             </button>
         </form>
     );

--- a/src/app/admin/block/divide/components/divide-preview.tsx
+++ b/src/app/admin/block/divide/components/divide-preview.tsx
@@ -1,6 +1,10 @@
-import Divider from "@components/divider";
+import Divider from '@components/divider';
 
-export default function DividePreview({ state }: { state: Block }) {
+export default function DividePreview({
+    divideStyle,
+}: {
+    divideStyle: number;
+}) {
     return (
         <>
             <p className="mb-2">미리보기</p>
@@ -31,8 +35,8 @@ export default function DividePreview({ state }: { state: Block }) {
 
                         <div className="relative flex h-2/5 w-full items-center justify-center">
                             <Divider
-                                style={state.style||1}
-                                className="relative flex justify-center items-center w-[30%]"
+                                style={divideStyle}
+                                className="relative flex w-[30%] items-center justify-center"
                             />
                         </div>
 

--- a/src/app/admin/block/divide/components/divide-selector.tsx
+++ b/src/app/admin/block/divide/components/divide-selector.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { Dispatch } from 'react';
-import DivideItem from './divide-item';
+import { twMerge } from 'tailwind-merge';
+import Divider from '@components/divider';
 export default function DivideSelector({
-    state,
-    dispatch,
+    divideStyle,
+    handleDivideStyleChange,
 }: {
-    state: Block;
-    dispatch: Dispatch<BlockFormAction>;
+    divideStyle: number;
+    handleDivideStyleChange: (index: number, title: string) => void;
 }) {
+    const descriptions = ['공백', '점선', '실선', '포인트', '지그재그'];
     return (
-        <>
+        <div>
             <p>
                 구분선 모양
                 <span className="title relative top-1 ml-2 inline-block text-red-500">
@@ -19,15 +20,29 @@ export default function DivideSelector({
             </p>
 
             <div className="flex h-32 w-full gap-4">
-                {Array.from({ length: 5 }).map((_, i) => (
-                    <DivideItem
-                        key={i}
-                        state={state}
-                        dispatch={dispatch}
-                        index={i}
-                    />
+                {descriptions.map((title, index) => (
+                    <div
+                        key={index + title}
+                        onClick={() =>
+                            handleDivideStyleChange(index, descriptions[index])
+                        }
+                        className="flex h-full w-20 flex-col gap-2"
+                    >
+                        <Divider
+                            style={index + 1}
+                            className={twMerge(
+                                'relative flex aspect-square w-full items-center justify-center rounded-lg border border-gray-300',
+                                divideStyle === index + 1
+                                    ? 'border-primary-450'
+                                    : '',
+                            )}
+                        />
+                        <p className="flex items-center justify-center">
+                            {title}
+                        </p>
+                    </div>
                 ))}
             </div>
-        </>
+        </div>
     );
 }

--- a/src/app/admin/block/divide/page.tsx
+++ b/src/app/admin/block/divide/page.tsx
@@ -1,63 +1,36 @@
 'use client';
 
-import { useReducer } from 'react';
-import { useRouter } from 'next/navigation';
-import { blockFormReducer, initialState } from 'reducer/block-form-reducer';
 import CloseButton from '../components/close-button';
 import DividePreview from './components/divide-preview';
 import DivideForm from './components/divide-form';
+import { useBlockSubmit } from 'hooks/useBlockSubmit';
+import { useState } from 'react';
+import useBlockStore from 'store/useBlockStore';
 
 export default function DivideBlock() {
-    const [state, dispatch] = useReducer<React.Reducer<Block, BlockFormAction>>(
-        blockFormReducer,
-        initialState,
+    const { block, handleSubmit, paramsId } = useBlockSubmit();
+    const { updateBlock } = useBlockStore();
+    const [divideStyle, setDivideStyle] = useState(
+        paramsId && block ? block.style : 1,
     );
-    const router = useRouter();
-
-    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-
-        if (state.style === null) {
-            alert('구분선을 선택해주세요');
-            return;
-        }
-
-        const formData: FormData = new FormData();
-        formData.set('type', '1');
-        // formData.set('sequence', 전역상태에서 가져오기);
-        // admin에서 api로 블록 리스트 호출하여 저장하고 length+1
-        formData.set('style', String(state.style!));
-
-        try {
-            const response = await fetch('/api/link/add', {
-                // headers: {
-                //   "Authorization": `Bearer ${token}`,
-                // },
-                // localStorage or 다른 거에 있는 token 가져오기
-                method: 'POST',
-                body: formData,
-            });
-            const result = await response.json();
-
-            if (result.code !== 200) {
-                throw new Error('구분선 블록 등록 실패');
-            }
-
-            // 필요하다면 flash message 구현
-            router.push('/admin');
-        } catch (error) {
-            console.error(error);
-
-            // flash message 구현
-        }
+    const [title, setTitle] = useState(paramsId && block ? block.title : '');
+    const handleDivideStyleChange = (index: number, title: string) => {
+        setDivideStyle(index + 1);
+        setTitle(title);
+        if (paramsId && block)
+            updateBlock(block.id, { style: index + 1, title });
     };
-
     return (
         <section className="p-10">
             <CloseButton />
             <h1 className="pageName mb-10">구분선 블록</h1>
-            <DividePreview state={state}/>
-            <DivideForm state={state} dispatch={dispatch} onSubmit={handleSubmit} />
+            <DividePreview divideStyle={divideStyle} />
+            <DivideForm
+                divideStyle={divideStyle}
+                title={title}
+                onSubmit={(e) => handleSubmit(e, 1)}
+                handleDivideStyleChange={handleDivideStyleChange}
+            />
         </section>
     );
 }

--- a/src/app/admin/block/image/components/image-form.tsx
+++ b/src/app/admin/block/image/components/image-form.tsx
@@ -1,20 +1,33 @@
 'use client';
 
-import { Dispatch } from 'react';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { checkImageOrientation } from 'service/validation';
 
 export default function ImageForm({
-    state,
-    dispatch,
     onSubmit,
+    title,
+    url,
+    imgUrl,
+    handleTitleChange,
 }: {
-    state: Block;
-    dispatch:  Dispatch<BlockFormAction>;
-    onSubmit:  (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+    onSubmit: (
+        e: React.FormEvent<HTMLFormElement>,
+        type: BlockType,
+    ) => Promise<void>;
+    title: string;
+    url: string;
+    imgUrl: string;
+    handleTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
-
+    const [imgOrientation, setImgOrientation] = useState(false);
+    useEffect(() => {
+        if (imgUrl) {
+            checkImageOrientation(imgUrl).then(setImgOrientation);
+        }
+    }, [imgUrl]);
     return (
-        <form action="/api/admin/add" method="POST" onSubmit={onSubmit}>
+        <form onSubmit={(e) => onSubmit(e, 4)} className="flex flex-col gap-4">
             <div className="mb-10 flex flex-col gap-2">
                 <label htmlFor="imgUrl">
                     이미지
@@ -28,29 +41,34 @@ export default function ImageForm({
                     id="imgUrl"
                     placeholder="원하는 이미지 URL을 알려주세요"
                     className="input"
-                    onChange={(e) => {
-                        dispatch({
-                            type: 'SET_BLOCK',
-                            payload: { imgUrl: e.target.value },
-                        });
-                    }}
+                    value={imgUrl}
+                    onChange={handleTitleChange}
                 />
             </div>
-            <div className="relative mb-10 h-[40rem] w-full">
-                <Image
-                    src="/assets/icons/icon_image.png"
-                    alt="image"
-                    fill
-                    style={{ objectFit: 'cover' }}
-                    className="brightness-0 filter"
-                />
-            </div>
+            {(imgUrl || title) && (
+                <div className="h-fit overflow-hidden rounded-lg bg-slate-300">
+                    {imgUrl && (
+                        <div className="relative aspect-square h-96 w-full">
+                            <Image
+                                src={imgUrl}
+                                alt="Image"
+                                fill
+                                objectFit={`${imgOrientation ? 'cover' : 'contain'}`}
+                            />
+                        </div>
+                    )}
+                    {title && (
+                        <p className="bg-slate-100 p-4 text-center">{title}</p>
+                    )}
+                </div>
+            )}
 
             <div className="mb-10 flex flex-col gap-2">
                 <div className="flex justify-between">
                     <label htmlFor="title">타이틀</label>
                     <p>
-                        {state.title?.length || 0} <span className="text-slate-300">/ 30</span>
+                        {title.length || 0}{' '}
+                        <span className="text-slate-300">/ 30</span>
                     </p>
                 </div>
                 <input
@@ -59,12 +77,8 @@ export default function ImageForm({
                     id="title"
                     placeholder="이미지 하단에 함께 보여줄 수 있어요"
                     className="input"
-                    onChange={(e) => {
-                        dispatch({
-                            type: 'SET_BLOCK',
-                            payload: { title: e.target.value },
-                        });
-                    }}
+                    value={title}
+                    onChange={handleTitleChange}
                 />
             </div>
 
@@ -76,12 +90,8 @@ export default function ImageForm({
                     id="url"
                     placeholder="이미지를 통해 이동시키고 싶은 링크가 있나요?"
                     className="input"
-                    onChange={(e) => {
-                        dispatch({
-                            type: 'SET_BLOCK',
-                            payload: { url: e.target.value },
-                        });
-                    }}
+                    value={url}
+                    onChange={handleTitleChange}
                 />
             </div>
 

--- a/src/app/admin/block/image/components/image-form.tsx
+++ b/src/app/admin/block/image/components/image-form.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useBlockSubmit } from 'hooks/useBlockSubmit';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { checkImageOrientation } from 'service/validation';
+import { checkImageOrientation, validateURL } from 'service/validation';
 
 export default function ImageForm({
     onSubmit,
@@ -20,6 +21,7 @@ export default function ImageForm({
     imgUrl: string;
     handleTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
+    const { paramsId } = useBlockSubmit();
     const [imgOrientation, setImgOrientation] = useState(false);
     useEffect(() => {
         if (imgUrl) {
@@ -95,7 +97,11 @@ export default function ImageForm({
                 />
             </div>
 
-            <button className="button color">추가 완료</button>
+            <button
+                className={`button color ${!validateURL(imgUrl) && 'disable'}`}
+            >
+                {paramsId ? '수정 완료' : '추가 완료'}
+            </button>
         </form>
     );
 }

--- a/src/app/admin/block/image/page.tsx
+++ b/src/app/admin/block/image/page.tsx
@@ -1,57 +1,38 @@
 'use client';
 
-import { useReducer } from 'react';
-import { useRouter } from 'next/navigation';
-import { blockFormReducer, initialState } from 'reducer/block-form-reducer';
+import { useState } from 'react';
 import CloseButton from '../components/close-button';
 import ImageForm from './components/image-form';
+import { useBlockSubmit } from 'hooks/useBlockSubmit';
+import useBlockStore from 'store/useBlockStore';
 
 export default function ImageBlock() {
-    const [state, dispatch] = useReducer<React.Reducer<Block, BlockFormAction>>(
-        blockFormReducer,
-        initialState,
-    );
-    const router = useRouter();
+    const { handleSubmit, block, paramsId } = useBlockSubmit();
+    const { updateBlock } = useBlockStore();
+    const [title, setTitle] = useState(paramsId ? block?.title : '');
+    const [url, setUrl] = useState(paramsId ? block?.url : '');
+    const [imgUrl, setImgUrl] = useState(paramsId ? block?.imgUrl : '');
 
-    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
+    const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        console.log(name, value);
+        if (name === 'title') setTitle(value);
+        if (name === 'url') setUrl(value);
+        if (name === 'imgUrl') setImgUrl(value);
 
-        const formData: FormData = new FormData();
-        formData.set('type', '4');
-        formData.set('title', state.title || '');
-        formData.set('url', state.url || '');
-        formData.set('imgUrl', state.imgUrl || '');
-        // formData.set('sequence', 전역상태에서 가져오기);
-
-        try {
-            const response = await fetch('/api/link/add', {
-                // headers: {
-                //   "Authorization": `Bearer ${token}`,
-                // },
-                // localStorage or 다른 거에 있는 token 가져오기
-                method: 'POST',
-                body: formData,
-            });
-            const result = await response.json();
-
-            if (result.code !== 200) {
-                throw new Error('이미지 블록 등록 실패');
-            }
-
-            // 필요하다면 flash message 구현
-
-            router.push('/admin');
-        } catch (error) {
-            // 필요하다면 flash message 구현
-            console.log(error);
-        }
+        if (paramsId && block) updateBlock(block.id, { [name]: value });
     };
-
     return (
         <section className="p-10">
             <CloseButton />
             <p className="pageName mb-10">이미지 블록</p>
-            <ImageForm state={state} dispatch={dispatch} onSubmit={handleSubmit} />
+            <ImageForm
+                onSubmit={handleSubmit}
+                title={title}
+                url={url}
+                imgUrl={imgUrl}
+                handleTitleChange={handleTitleChange}
+            />
         </section>
     );
 }

--- a/src/app/admin/block/link/components/link-form.tsx
+++ b/src/app/admin/block/link/components/link-form.tsx
@@ -13,14 +13,10 @@ export default function LinkForm({
     url,
     paramsId,
     imgUrl,
-    file,
     handleFileChange,
     handleDeleteImg,
 }: {
-    onSubmit: (
-        e: React.FormEvent<HTMLFormElement>,
-        type: BlockType,
-    ) => Promise<void>;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
     selectedStyle: number;
     handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     handleStyleChange: (index: number) => void;
@@ -28,17 +24,11 @@ export default function LinkForm({
     url: string;
     paramsId: string | null;
     imgUrl: string;
-    file: File | null;
     handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     handleDeleteImg: () => void;
 }) {
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        if (!validateURL(url)) return alert('올바른 URL을 입력해주세요');
-        onSubmit(e, 3);
-    };
     return (
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={onSubmit}>
             <LinkStyleSelector
                 selectedStyle={selectedStyle}
                 handleStyleChange={handleStyleChange}
@@ -85,7 +75,7 @@ export default function LinkForm({
                 </label>
                 <div className="flex items-center justify-center gap-4">
                     <div className="relative flex h-48 w-48 items-center justify-center rounded-lg border-2 border-gray-300 bg-gray-300">
-                        {file || imgUrl ? (
+                        {imgUrl ? (
                             <Image
                                 src={imgUrl}
                                 alt="Uploaded"

--- a/src/app/admin/block/link/components/link-form.tsx
+++ b/src/app/admin/block/link/components/link-form.tsx
@@ -1,45 +1,44 @@
 import Image from 'next/image';
 import LinkStyleSelector from './link-style-selector';
-import { Dispatch, useState } from 'react';
-import useBlockStore from 'store/useBlockStore';
+import { RiDeleteBin6Line } from 'react-icons/ri';
+import { LuPen } from 'react-icons/lu';
+import { validateURL } from 'service/validation';
 
 export default function LinkForm({
-    state,
     onSubmit,
     selectedStyle,
-    setSelectedStyle,
+    handleInputChange,
+    handleStyleChange,
+    title,
+    url,
+    paramsId,
+    imgUrl,
+    file,
+    handleFileChange,
+    handleDeleteImg,
 }: {
-    state: Block | null;
-    onSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+    onSubmit: (
+        e: React.FormEvent<HTMLFormElement>,
+        type: BlockType,
+    ) => Promise<void>;
     selectedStyle: number;
-    setSelectedStyle: Dispatch<React.SetStateAction<number>>;
+    handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    handleStyleChange: (index: number) => void;
+    title: string;
+    url: string;
+    paramsId: string | null;
+    imgUrl: string;
+    file: File | null;
+    handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    handleDeleteImg: () => void;
 }) {
-    const [file, setFile] = useState<File | null>(null);
-    const [fileUrl, setFileUrl] = useState<string>('');
-    const [title, setTitle] = useState<string>('');
-    const [url, setUrl] = useState<string>('');
-    const { updateBlock } = useBlockStore();
-
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        name === 'title' && setTitle(value);
-        name === 'url' && setUrl(value);
-        if (state) {
-            name === 'title' && updateBlock(state.id, { title: value });
-            name === 'url' && updateBlock(state.id, { url: value });
-        }
-    };
-    const handleStyleChange = (index: number) => {
-        setSelectedStyle(index + 1);
-        if (state) updateBlock(state.id, { style: index });
-    };
-    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const selectedFile = e.target.files?.[0];
-        setFile(selectedFile || null);
-        setFileUrl(selectedFile ? URL.createObjectURL(selectedFile) : '');
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!validateURL(url)) return alert('올바른 URL을 입력해주세요');
+        onSubmit(e, 3);
     };
     return (
-        <form onSubmit={onSubmit}>
+        <form onSubmit={handleSubmit}>
             <LinkStyleSelector
                 selectedStyle={selectedStyle}
                 handleStyleChange={handleStyleChange}
@@ -57,7 +56,7 @@ export default function LinkForm({
                     id="url"
                     placeholder="연결하고 싶은 링크 주소 전체를 입력해주세요"
                     className="input"
-                    value={state?.url || url}
+                    value={url}
                     onChange={handleInputChange}
                 />
             </div>
@@ -75,7 +74,7 @@ export default function LinkForm({
                     id="title"
                     placeholder="링크는 잘 나타낼 수 있는 이름으로 입력해주세요"
                     className="input"
-                    value={state?.title || title}
+                    value={title}
                     onChange={handleInputChange}
                 />
             </div>
@@ -86,9 +85,9 @@ export default function LinkForm({
                 </label>
                 <div className="flex items-center justify-center gap-4">
                     <div className="relative flex h-48 w-48 items-center justify-center rounded-lg border-2 border-gray-300 bg-gray-300">
-                        {file ? (
+                        {file || imgUrl ? (
                             <Image
-                                src={URL.createObjectURL(file)}
+                                src={imgUrl}
                                 alt="Uploaded"
                                 className="h-full w-full rounded-lg object-cover"
                                 width={100}
@@ -106,22 +105,40 @@ export default function LinkForm({
                         )}
                         <input
                             type="file"
+                            id="file"
                             className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                             onChange={handleFileChange}
                         />
-                        <input type="hidden" name="imgUrl" value={fileUrl} />
+                        <input type="hidden" name="imgUrl" value={imgUrl} />
                     </div>
                     <div className="text-sm">
-                        <p>
-                            이미지를 직접 끌어오거나 <br />
-                            파일을 선택하여 업로드 해주세요
-                        </p>
+                        {!imgUrl ? (
+                            <p>
+                                이미지를 직접 끌어오거나 <br />
+                                파일을 선택하여 업로드 해주세요
+                            </p>
+                        ) : (
+                            <div className="flex items-center gap-2">
+                                <label
+                                    htmlFor="file"
+                                    className="aspect-square w-14 cursor-pointer overflow-hidden rounded-full"
+                                >
+                                    <LuPen className="h-full w-full bg-primary p-2" />
+                                </label>
+                                <button
+                                    className="aspect-square w-14 cursor-pointer overflow-hidden rounded-full"
+                                    onClick={handleDeleteImg}
+                                >
+                                    <RiDeleteBin6Line className="h-full w-full bg-slate-500 p-2" />
+                                </button>
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>
 
             <button className="button color">
-                {state ? '수정 완료' : '추가 완료'}
+                {paramsId ? '수정 완료' : '추가 완료'}
             </button>
         </form>
     );

--- a/src/app/admin/block/link/components/link-form.tsx
+++ b/src/app/admin/block/link/components/link-form.tsx
@@ -127,7 +127,9 @@ export default function LinkForm({
                 </div>
             </div>
 
-            <button className="button color">
+            <button
+                className={`button color ${(!validateURL(url) || !title) && 'disable'}`}
+            >
                 {paramsId ? '수정 완료' : '추가 완료'}
             </button>
         </form>

--- a/src/app/admin/block/link/components/link-preview.tsx
+++ b/src/app/admin/block/link/components/link-preview.tsx
@@ -1,33 +1,24 @@
 import Image from 'next/image';
 import useBlockStore from 'store/useBlockStore';
+import LinkStyle from './link-style';
+import { useBlockSubmit } from 'hooks/useBlockSubmit';
 
 export default function LinkPreview({
     title,
     selectedStyle,
+    imgUrl,
 }: {
-    title: string | null;
+    title: string;
     selectedStyle: number;
+    imgUrl: string;
 }) {
-    const { block } = useBlockStore();
     return (
         <div className="mb-10 flex h-fit min-h-20 w-full items-center justify-center bg-slate-100 px-4 py-4">
-            <div className="flex h-full min-h-16 w-5/6 justify-between rounded-lg bg-white p-1 shadow-lg">
-                {selectedStyle === 1 && (
-                    <div className="aspect-square h-full rounded-lg bg-slate-300">
-                        <Image
-                            src={block?.imgUrl || ''}
-                            alt="link-preview"
-                            width={100}
-                            height={100}
-                        />
-                    </div>
-                )}
-
-                <div className="flex grow items-center justify-center">
-                    <p>{title || '타이틀을 입력해주세요'}</p>
-                    <p>{selectedStyle}</p>
-                </div>
-            </div>
+            <LinkStyle
+                title={title}
+                selectedStyle={selectedStyle}
+                imgUrl={imgUrl}
+            />
         </div>
     );
 }

--- a/src/app/admin/block/link/components/link-style-selector.tsx
+++ b/src/app/admin/block/link/components/link-style-selector.tsx
@@ -1,7 +1,6 @@
-import { Dispatch, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import Image from 'next/image';
-
+import { FaCheckCircle } from 'react-icons/fa';
 export default function LinkStyleSelector({
     selectedStyle,
     handleStyleChange,
@@ -42,6 +41,11 @@ export default function LinkStyleSelector({
                                 style={{ objectFit: 'contain' }}
                                 className="px-8 py-2"
                             />
+                            {selectedStyle === index + 1 && (
+                                <FaCheckCircle
+                                    className={`absolute bottom-1 right-2 rounded-full bg-white text-primary`}
+                                />
+                            )}
                         </div>
                         <p className="text-center">{descriptions[index]}</p>
                     </div>

--- a/src/app/admin/block/link/components/link-style.tsx
+++ b/src/app/admin/block/link/components/link-style.tsx
@@ -1,0 +1,66 @@
+import Image from 'next/image';
+
+export default function LinkStyle({
+    title,
+    selectedStyle,
+    imgUrl,
+}: {
+    title: string;
+    selectedStyle: number;
+    imgUrl: string;
+}) {
+    console.log(selectedStyle);
+    return (
+        <div
+            className={`relative flex h-full min-h-16 w-5/6 overflow-hidden rounded-lg bg-white shadow-lg ${selectedStyle === 3 && 'flex-col'} ${selectedStyle === 1 && 'p-2'}`}
+        >
+            {selectedStyle === 1 && (
+                <div className="relative aspect-square h-20 overflow-hidden rounded-lg bg-slate-300">
+                    {imgUrl && (
+                        <Image
+                            src={imgUrl}
+                            alt="link-image"
+                            layout="fill"
+                            objectFit="cover"
+                            objectPosition="center"
+                            className="absolute inset-0 z-0"
+                        />
+                    )}
+                </div>
+            )}
+            {selectedStyle === 2 && (
+                <div className="h-full rounded-lg bg-slate-300">
+                    {imgUrl && (
+                        <Image
+                            src={imgUrl}
+                            alt="link-image"
+                            layout="fill"
+                            objectFit="cover"
+                            className="absolute inset-0 z-0"
+                        />
+                    )}
+                </div>
+            )}
+
+            {selectedStyle === 3 && (
+                <div className="relative aspect-square h-96 rounded-t-lg bg-slate-300">
+                    {imgUrl && (
+                        <Image
+                            src={imgUrl}
+                            alt="link-image"
+                            layout="fill"
+                            objectFit="cover"
+                            className="absolute inset-0 z-0"
+                        />
+                    )}
+                </div>
+            )}
+
+            <div
+                className={`${selectedStyle === 2 && !imgUrl && 'bg-slate-300'} z-10 flex min-h-16 grow items-center justify-center`}
+            >
+                <p>{title || '타이틀을 입력해주세요'}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/block/link/page.tsx
+++ b/src/app/admin/block/link/page.tsx
@@ -18,7 +18,6 @@ export default function LinkBlock() {
     const [url, setUrl] = useState<string>(
         paramsId ? blockState?.url || '' : '',
     );
-    const [file, setFile] = useState<File | null>(null);
     const [imgUrl, setImgUrl] = useState<string>(
         paramsId ? blockState?.imgUrl || '' : '',
     );
@@ -78,7 +77,6 @@ export default function LinkBlock() {
                 url={url}
                 paramsId={paramsId}
                 imgUrl={imgUrl}
-                file={file}
                 handleFileChange={handleFileChange}
                 handleDeleteImg={handleDeleteImg}
             />

--- a/src/app/admin/block/link/page.tsx
+++ b/src/app/admin/block/link/page.tsx
@@ -5,26 +5,71 @@ import LinkPreview from './components/link-preview';
 import LinkForm from './components/link-form';
 import { useBlockSubmit } from 'hooks/useBlockSubmit';
 import { useState } from 'react';
+import useBlockStore from 'store/useBlockStore';
 
 export default function LinkBlock() {
     const { handleSubmit, block: blockState, paramsId } = useBlockSubmit();
     const [selectedStyle, setSelectedStyle] = useState<number>(
         paramsId ? blockState?.style || 1 : 1,
     );
-
+    const [title, setTitle] = useState<string>(
+        paramsId ? blockState?.title || '' : '',
+    );
+    const [url, setUrl] = useState<string>(
+        paramsId ? blockState?.url || '' : '',
+    );
+    const [file, setFile] = useState<File | null>(null);
+    const [imgUrl, setImgUrl] = useState<string>(
+        paramsId ? blockState?.imgUrl || '' : '',
+    );
+    const { updateBlock } = useBlockStore();
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedFile = e.target.files?.[0];
+        setImgUrl(selectedFile ? URL.createObjectURL(selectedFile) : '');
+        if (paramsId && blockState)
+            updateBlock(blockState.id, {
+                imgUrl: selectedFile ? URL.createObjectURL(selectedFile) : '',
+            });
+    };
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        name === 'title' && setTitle(value);
+        name === 'url' && setUrl(value);
+        if (paramsId && blockState) {
+            name === 'title' && updateBlock(blockState.id, { title: value });
+            name === 'url' && updateBlock(blockState.id, { url: value });
+        }
+    };
+    const handleDeleteImg = () => {
+        setImgUrl('');
+        if (paramsId && blockState) updateBlock(blockState.id, { imgUrl: '' });
+    };
+    const handleStyleChange = (index: number) => {
+        setSelectedStyle(index + 1);
+        if (paramsId && blockState)
+            updateBlock(blockState.id, { style: index + 1 });
+    };
     return (
         <div className="p-10">
             <CloseButton />
             <p className="pageName mb-10">링크 블록</p>
             <LinkPreview
-                title={blockState?.title || null}
+                title={title}
                 selectedStyle={selectedStyle}
+                imgUrl={imgUrl}
             />
             <LinkForm
-                state={paramsId ? blockState : null}
                 onSubmit={(e) => handleSubmit(e, 3)}
                 selectedStyle={selectedStyle}
-                setSelectedStyle={setSelectedStyle}
+                handleInputChange={handleInputChange}
+                handleStyleChange={handleStyleChange}
+                title={title}
+                url={url}
+                paramsId={paramsId}
+                imgUrl={imgUrl}
+                file={file}
+                handleFileChange={handleFileChange}
+                handleDeleteImg={handleDeleteImg}
             />
         </div>
     );

--- a/src/app/admin/block/text/components/text-form.tsx
+++ b/src/app/admin/block/text/components/text-form.tsx
@@ -25,12 +25,7 @@ export default function TextForm({
         }
     };
     return (
-        <form
-            onSubmit={onSubmit}
-            method="POST"
-            action="/api/admin/add"
-            className="mb-10 flex flex-col gap-2"
-        >
+        <form onSubmit={onSubmit} className="mb-10 flex flex-col gap-2">
             <div className="flex justify-between">
                 <label htmlFor="content">
                     내용 입력
@@ -52,7 +47,7 @@ export default function TextForm({
                 onChange={handleChange}
             />
 
-            <button className="button color">
+            <button className={`button color ${!inputValue && 'disable'}`}>
                 {state ? '수정 완료' : '추가 완료'}
             </button>
         </form>

--- a/src/app/admin/block/video/components/video-form.tsx
+++ b/src/app/admin/block/video/components/video-form.tsx
@@ -44,8 +44,6 @@ export default function VideoForm() {
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const inputUrl = e.target.value;
         setUrl(inputUrl);
-        if (!validateURL(inputUrl) && inputUrl !== '')
-            return alert('올바른 주소를 입력해주세요');
 
         const cleanVideoId = getVideoId(inputUrl);
 
@@ -88,7 +86,11 @@ export default function VideoForm() {
             <input type="hidden" name="title" value={title} />
             <input type="hidden" name="imgUrl" value={thumbnail} />
             <VideoEmbed url={embedUrl} />
-            <button className="button color">추가 완료</button>
+            <button
+                className={`button color ${!validateURL(url) && 'disable'}`}
+            >
+                {paramsId ? '수정 완료' : '추가 완료'}
+            </button>
         </form>
     );
 }

--- a/src/app/admin/block/video/components/video-form.tsx
+++ b/src/app/admin/block/video/components/video-form.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import VideoEmbed from './video-embed';
 import useBlockStore from 'store/useBlockStore';
 import { useBlockSubmit } from 'hooks/useBlockSubmit';
+import { validateURL } from 'service/validation';
 
 export default function VideoForm() {
     const { block, updateBlock } = useBlockStore();
@@ -12,10 +13,7 @@ export default function VideoForm() {
     const [embedUrl, setEmbedUrl] = useState<string>('');
     const [thumbnail, setThumbnail] = useState<string>('');
     const [title, setTitle] = useState<string>('');
-    const validateURL = (url: string) => {
-        const regex = /^(ftp|http|https):\/\/[^ "]+$/;
-        return regex.test(url);
-    };
+
     const getVideoId = (url: string) => {
         const videoId = url.split('v=')[1];
         const ampersandPosition = videoId ? videoId.indexOf('&') : -1;

--- a/src/app/admin/block/video/page.tsx
+++ b/src/app/admin/block/video/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import { useReducer } from 'react';
-import { useRouter } from 'next/navigation';
-import { blockFormReducer, initialState } from 'reducer/block-form-reducer';
 import CloseButton from '../components/close-button';
 import VideoForm from './components/video-form';
-import { useBlockSubmit } from 'hooks/useBlockSubmit';
-import useBlockStore from 'store/useBlockStore';
 
 export default function VideoBlock() {
     return (

--- a/src/app/admin/components/block.tsx
+++ b/src/app/admin/components/block.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import useToken from 'store/useToken';
 import useBlockStore from 'store/useBlockStore';
 import { deleteBlock } from 'service/api/admin-api';
+import Divider from '@components/divider';
 
 interface BlockProps extends Block {
     index: number;
@@ -142,7 +143,6 @@ export default function Block({
             <div
                 className="relative flex-1 cursor-pointer p-3"
                 onClick={() => {
-                    console.log('click!!');
                     handleClick(
                         blockTypeMap[rest.type].href + `?id=${rest.id}`,
                     );
@@ -160,6 +160,15 @@ export default function Block({
                 </div>
                 <div className={`flex gap-2`}>
                     {/* content */}
+                    {rest.type === 1 && (
+                        <div className="flex h-full w-full flex-col gap-3">
+                            <p className="">{rest.title}</p>
+                            <Divider
+                                className="flex h-full items-center justify-center"
+                                style={rest.style}
+                            />
+                        </div>
+                    )}
                     {rest.type === 5 && (
                         <Event
                             title={rest.title}
@@ -170,7 +179,7 @@ export default function Block({
                     {rest.schedule && rest.schedule.length > 0 && (
                         <Schedule schedule={rest.schedule} />
                     )}
-                    {rest.type !== 5 && rest.type !== 7 && (
+                    {rest.type !== 1 && rest.type !== 5 && rest.type !== 7 && (
                         <>
                             {rest.imgUrl && (
                                 <div className="relative aspect-square h-16 overflow-hidden rounded-md">

--- a/src/app/admin/components/block.tsx
+++ b/src/app/admin/components/block.tsx
@@ -167,17 +167,21 @@ export default function Block({
                             dateEnd={rest.dateEnd}
                         />
                     )}
-                    {rest.schedule && <Schedule schedule={rest.schedule} />}
+                    {rest.schedule && rest.schedule.length > 0 && (
+                        <Schedule schedule={rest.schedule} />
+                    )}
                     {rest.type !== 5 && rest.type !== 7 && (
                         <>
                             {rest.imgUrl && (
-                                <Image
-                                    src={rest.imgUrl}
-                                    alt={''}
-                                    width={56}
-                                    height={56}
-                                    className="rounded-md"
-                                />
+                                <div className="relative aspect-square h-16 overflow-hidden rounded-md">
+                                    <Image
+                                        src={rest.imgUrl}
+                                        alt={''}
+                                        layout="fill"
+                                        className="rounded-md"
+                                        objectFit="cover"
+                                    />
+                                </div>
                             )}
                             <div>{rest.title}</div>
                         </>

--- a/src/components/divider.tsx
+++ b/src/components/divider.tsx
@@ -22,9 +22,7 @@ export default function Divider({
             )}
             {style === 4 && (
                 <div className={className}>
-                    <span className="absoluteright-0 text-2xl text-black">
-                        • • •
-                    </span>
+                    <span className="text-xl text-black">• • •</span>
                 </div>
             )}
             {style === 5 && (

--- a/src/hooks/useBlockSubmit.ts
+++ b/src/hooks/useBlockSubmit.ts
@@ -2,6 +2,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import useBlockStore from 'store/useBlockStore';
 import useToken from 'store/useToken';
 import { addBlock, updateBlock } from 'service/api/block-api';
+import { validateURL } from 'service/validation';
 
 export function useBlockSubmit() {
     const router = useRouter();
@@ -17,13 +18,19 @@ export function useBlockSubmit() {
         if (!token) return;
 
         try {
+            // 블록 수정
             if (id) {
-                await updateBlock({
-                    accessToken: token,
-                    blockData: block!,
-                });
-                console.log(blocks, 'update', block);
+                if (validateURL(block?.url)) {
+                    await updateBlock({
+                        accessToken: token,
+                        blockData: block!,
+                    });
+                    console.log(blocks, 'update', block);
+                } else {
+                    return alert('올바른 URL을 입력해주세요');
+                }
             } else {
+                // 블록 추가
                 const formData = new FormData(e.currentTarget);
                 const formEntries = Object.fromEntries(formData.entries());
                 console.log(formEntries, 'formEntries');
@@ -39,8 +46,11 @@ export function useBlockSubmit() {
                 if ('style' in newBlock) {
                     newBlock.style = Number(newBlock.style);
                 }
-                console.log(blocks, 'add', newBlock);
 
+                if ('url' in newBlock) {
+                    if (newBlock.url && !validateURL(newBlock.url))
+                        return alert('올바른 URL을 입력해주세요');
+                }
                 await addBlock({
                     accessToken: token,
                     blockData: newBlock,

--- a/src/hooks/useBlockSubmit.ts
+++ b/src/hooks/useBlockSubmit.ts
@@ -16,30 +16,31 @@ export function useBlockSubmit() {
         e.preventDefault();
         if (!token) return;
 
-        const formData = new FormData(e.currentTarget);
-        const formEntries = Object.fromEntries(formData.entries());
-        console.log(formEntries, 'formEntries');
-        const maxSequence = blocks
-            ? Math.max(...blocks.map((b) => b.sequence), 0)
-            : 0;
-
-        const newBlock: T = {
-            ...formEntries,
-            type: blockType,
-            sequence: maxSequence + 1,
-        } as T;
-        if ('style' in newBlock) {
-            newBlock.style = Number(newBlock.style);
-        }
-        console.log(blocks, 'submit', newBlock);
-
         try {
             if (id) {
                 await updateBlock({
                     accessToken: token,
                     blockData: block!,
                 });
+                console.log(blocks, 'update', block);
             } else {
+                const formData = new FormData(e.currentTarget);
+                const formEntries = Object.fromEntries(formData.entries());
+                console.log(formEntries, 'formEntries');
+                const maxSequence = blocks
+                    ? Math.max(...blocks.map((b) => b.sequence), 0)
+                    : 0;
+
+                const newBlock: T = {
+                    ...formEntries,
+                    type: blockType,
+                    sequence: maxSequence + 1,
+                } as T;
+                if ('style' in newBlock) {
+                    newBlock.style = Number(newBlock.style);
+                }
+                console.log(blocks, 'add', newBlock);
+
                 await addBlock({
                     accessToken: token,
                     blockData: newBlock,

--- a/src/hooks/useBlockSubmit.ts
+++ b/src/hooks/useBlockSubmit.ts
@@ -20,14 +20,14 @@ export function useBlockSubmit() {
         try {
             // 블록 수정
             if (id) {
-                if (validateURL(block?.url)) {
+                if (block.url && !validateURL(block?.url)) {
+                    return alert('올바른 URL을 입력해주세요');
+                } else {
+                    console.log(blocks, 'update', block);
                     await updateBlock({
                         accessToken: token,
                         blockData: block!,
                     });
-                    console.log(blocks, 'update', block);
-                } else {
-                    return alert('올바른 URL을 입력해주세요');
                 }
             } else {
                 // 블록 추가

--- a/src/service/validation/index.ts
+++ b/src/service/validation/index.ts
@@ -1,4 +1,18 @@
+// url 확인
 export const validateURL = (url: string) => {
     const regex = /^(ftp|http|https):\/\/[^ "]+$/;
     return regex.test(url);
+};
+
+// 이미지 가로 세로 확인 (true : 가로)
+export const checkImageOrientation = (url: string): Promise<boolean> => {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.src = url;
+        img.onload = () => {
+            const isLandscape = img.width > img.height;
+            resolve(isLandscape);
+        };
+        img.onerror = (error) => reject(error);
+    });
 };

--- a/src/service/validation/index.ts
+++ b/src/service/validation/index.ts
@@ -1,0 +1,4 @@
+export const validateURL = (url: string) => {
+    const regex = /^(ftp|http|https):\/\/[^ "]+$/;
+    return regex.test(url);
+};


### PR DESCRIPTION
## :white_check_mark:DONE

- 이미지, 구분선 블록 추가, 수정 api
- 완료버튼 비활성화
- 이미지 블록  이미지URL 입력 시 미리 보기 이미지 비율 처리
- 링크 블록 이미지 수정, 삭제 버튼 추가
- admin 페이지 블록 리스트에 캘린더 블록 있을 때 겹치게 나오는것 수 
## :white_check_mark:TODO

- 미리 보기 이미지 컴포넌트 분리
- admin private 버튼 만들기
- block active 버튼 api 연동하기
- 링크 블록 이미지 추가 방법 생각하기..? ( firebase ..?)

## :white_check_mark:RESULT

| admin 블록 수정 전                                                                                                     | 수정 후                                                                                                     |
| :----------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------: |
|![image](https://github.com/user-attachments/assets/68fe94d3-b719-432d-bb0b-e31014fcb601)|![image](https://github.com/user-attachments/assets/ba75b2c1-9077-4ee9-a440-591244faa427)|
|이미지 비율 수정    |이미지 비율 수정   |
| ![image](https://github.com/user-attachments/assets/77ac4b99-88cb-4a0f-898f-dc38a5a9cac5)) | ![image](https://github.com/user-attachments/assets/e0a34e54-c08b-4c22-a9dc-88134ad18c06) |

